### PR TITLE
Merchant find all endpoints

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'factory_bot_rails'
   gem "table_print"
+  gem 'pry'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,6 +41,7 @@ GEM
     arel (8.0.0)
     builder (3.2.3)
     byebug (11.0.1)
+    coderay (1.1.2)
     concurrent-ruby (1.1.5)
     crass (1.0.4)
     diff-lcs (1.3)
@@ -76,6 +77,9 @@ GEM
     nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     pg (1.1.4)
+    pry (0.12.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
     puma (3.12.1)
     rack (2.0.7)
     rack-test (1.1.0)
@@ -161,6 +165,7 @@ DEPENDENCIES
   fast_jsonapi
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)
+  pry
   puma (~> 3.7)
   rails (~> 5.1.7)
   rspec-rails

--- a/app/controllers/api/v1/merchants/search_controller.rb
+++ b/app/controllers/api/v1/merchants/search_controller.rb
@@ -4,7 +4,7 @@ class Api::V1::Merchants::SearchController < ApplicationController
     when 'id'
       Merchant.find_by( search_params )
     when 'name'
-      Merchant.find_by_lower_name( search_params[:name] )
+      Merchant.find_by_lower_name( search_params[:name], all: false )
     when 'created_at'
       Merchant.find_by_flex_date(created_at: search_params[:created_at])
     when 'updated_at'

--- a/app/controllers/api/v1/merchants/search_controller.rb
+++ b/app/controllers/api/v1/merchants/search_controller.rb
@@ -13,6 +13,17 @@ class Api::V1::Merchants::SearchController < ApplicationController
     render json: MerchantSerializer.new( merchant )
   end
 
+  def index
+    merchant = case search_params.keys.first
+    when 'id'
+      Merchant.all_by_id( search_params[:id] )
+    when 'name'
+    when 'created_at'
+    when 'updated_at'
+    end
+    render json: MerchantSerializer.new( merchant )
+  end
+
   private
 
   def search_params

--- a/app/controllers/api/v1/merchants/search_controller.rb
+++ b/app/controllers/api/v1/merchants/search_controller.rb
@@ -5,10 +5,13 @@ class Api::V1::Merchants::SearchController < ApplicationController
       Merchant.find_by( search_params )
     when 'name'
       Merchant.find_by_lower_name( search_params[:name], all: false )
-    when 'created_at'
-      Merchant.find_by_flex_date(created_at: search_params[:created_at])
-    when 'updated_at'
-      Merchant.find_by_flex_date(updated_at: search_params[:updated_at])
+    when 'created_at', 'updated_at'
+      # Merchant.find_by_flex_date(created_at: search_params[:created_at])
+      Merchant.where( search_params ).first
+    # when 'updated_at'
+    #   # Merchant.find_by_flex_date(updated_at: search_params[:updated_at])
+    #   Merchant.where( search_params ).first
+
     end
     render json: MerchantSerializer.new( merchant )
   end
@@ -16,10 +19,17 @@ class Api::V1::Merchants::SearchController < ApplicationController
   def index
     merchant = case search_params.keys.first
     when 'id'
-      Merchant.all_by_id( search_params[:id] )
+      Merchant.where( search_params )
     when 'name'
-    when 'created_at'
-    when 'updated_at'
+      Merchant.find_by_lower_name( search_params[:name] )
+    when 'created_at', 'updated_at'
+      # Merchant.find_by_flex_date(created_at: search_params[:created_at])
+      Merchant.where( search_params )
+
+    # when 'updated_at'
+    #   # Merchant.find_by_flex_date(updated_at: search_params[:updated_at])
+    #   Merchant.where( search_params )
+
     end
     render json: MerchantSerializer.new( merchant )
   end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -39,8 +39,9 @@ class Merchant < ApplicationRecord
     result.first
   end
 
-  def self.find_by_lower_name(name)
-    where('lower(name) like ?', "%#{name.downcase}%").first
+  def self.find_by_lower_name(name, all: true)
+    result = where('lower(name) like ?', "%#{name.downcase}%")
+    all ? result : result.first
   end
 
   def self.find_by_flex_date(args)

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -48,6 +48,10 @@ class Merchant < ApplicationRecord
     where(args).first
   end
 
+  def self.all_by_id(id)
+    where(id: id)
+  end
+
   def favorite_customer
     sql = "SELECT c.*, count(*) as num_transactions " +
             "FROM customers c " +

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
         get '/:merchant_id/items', to: 'items#index'
         get '/:merchant_id/invoices', to: 'invoices#index'
         get '/find', to: 'search#show'
+        get '/find_all', to: 'search#index'
       end
 
       resources :merchants, only: [:index, :show]

--- a/spec/factories/merchant.rb
+++ b/spec/factories/merchant.rb
@@ -1,5 +1,7 @@
 FactoryBot.define do
   factory :merchant do
     sequence(:name) { |x| "Bob Ross Paints #{x}" }
+    created_at { Time.now }
+    updated_at { created_at }
   end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -65,10 +65,15 @@ describe Merchant do
 
     it '::find_by_lower_name' do
       merchant = create(:merchant, name: 'Bob Shop')
+      merchant_2 = create(:merchant, name: 'Bob Shop 2')
 
-      expect(Merchant.find_by_lower_name('Bob Shop')).to eq(merchant)
-      expect(Merchant.find_by_lower_name('bob shop')).to eq(merchant)
-      expect(Merchant.find_by_lower_name('BOB SHOP')).to eq(merchant)
+      expect(Merchant.find_by_lower_name('Bob Shop', all: false)).to eq(merchant)
+      expect(Merchant.find_by_lower_name('bob shop', all: false)).to eq(merchant)
+      expect(Merchant.find_by_lower_name('BOB SHOP', all: false)).to eq(merchant)
+
+      expect(Merchant.find_by_lower_name('bob shop')).to eq([merchant, merchant_2])
+
+      expect(Merchant.find_by_lower_name('bob')).to eq([merchant, merchant_2])
     end
 
     it '::find_by_flex_date' do

--- a/spec/requests/api/v1/merchants_search_request_spec.rb
+++ b/spec/requests/api/v1/merchants_search_request_spec.rb
@@ -75,4 +75,15 @@ describe 'Merchants API' do
 
     expect(json['data'].first['id']).to eq(merchant_2.id.to_s)
   end
+
+  it 'can find all merchants by name' do
+    merchant_1 = create(:merchant)
+    merchant_2 = create(:merchant)
+
+    get "/api/v1/merchants/find_all?id=#{merchant_2.id}"
+
+    json = JSON.parse (response.body)
+
+    expect(json['data'].first['id']).to eq(merchant_2.id.to_s)
+  end
 end

--- a/spec/requests/api/v1/merchants_search_request_spec.rb
+++ b/spec/requests/api/v1/merchants_search_request_spec.rb
@@ -71,6 +71,8 @@ describe 'Merchants API' do
 
     get "/api/v1/merchants/find_all?id=#{merchant_2.id}"
 
+    expect(response).to be_successful
+
     json = JSON.parse (response.body)
 
     expect(json['data'].first['id']).to eq(merchant_2.id.to_s)
@@ -80,10 +82,28 @@ describe 'Merchants API' do
     merchant_1 = create(:merchant)
     merchant_2 = create(:merchant)
 
-    get "/api/v1/merchants/find_all?id=#{merchant_2.id}"
+    get "/api/v1/merchants/find_all?name=#{merchant_2.name}"
+
+    expect(response).to be_successful
 
     json = JSON.parse (response.body)
 
     expect(json['data'].first['id']).to eq(merchant_2.id.to_s)
+  end
+
+  it 'can find all merchants by created_at' do
+    merchant_1 = create(:merchant, created_at: '2019-09-08 12:34:23 UTC')
+    merchant_2 = create(:merchant, created_at: '2019-09-08 12:34:23 UTC')
+    merchant_3 = create(:merchant, created_at: '2019-09-08 12:37:34 UTC')
+    merchant_4 = create(:merchant, created_at: '2019-09-08 12:45:45 UTC')
+
+    get "/api/v1/merchants/find_all?created_at=2019-09-08T12:34:23"
+
+    expect(response).to be_successful
+    json = JSON.parse (response.body)
+    expect(json['data'][0]['id']).to eq(merchant_1.id.to_s)
+    expect(json['data'][1]['id']).to eq(merchant_2.id.to_s)
+
+    expect(json['data'].count).to eq(2)
   end
 end

--- a/spec/requests/api/v1/merchants_search_request_spec.rb
+++ b/spec/requests/api/v1/merchants_search_request_spec.rb
@@ -64,4 +64,15 @@ describe 'Merchants API' do
     expect(json['data']['id']).to eq(merchant_2.id.to_s)
     expect([json['data']].count).to eq(1)
   end
+
+  it 'can find all merchants by id' do
+    merchant_1 = create(:merchant)
+    merchant_2 = create(:merchant)
+
+    get "/api/v1/merchants/find_all?id=#{merchant_2.id}"
+
+    json = JSON.parse (response.body)
+
+    expect(json['data'].first['id']).to eq(merchant_2.id.to_s)
+  end
 end


### PR DESCRIPTION
- Users can use the endpoint `/api/v1/merchants/find_all` with query params:
    - ?id=x
    - ?name=x
    - ?created_at=x
    - ?updated_at=x
to find all records that match query