### PR TITLE
Item best day endpoint

### DIFF
--- a/app/controllers/api/v1/items/best_day_controller.rb
+++ b/app/controllers/api/v1/items/best_day_controller.rb
@@ -1,0 +1,6 @@
+class Api::V1::Items::BestDayController < ApplicationController
+  def show
+    item = Item.find_by_id(params[:id])
+    render json: BestDaySerializer.new(item.best_day).json
+  end
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -33,7 +33,7 @@ class Item < ApplicationRecord
           "INNER JOIN transactions t ON inv.id = t.invoice_id " +
           "WHERE t.result = 'success' AND i.id = #{id} " +
           "GROUP BY date " +
-          "ORDER BY num_sold DESC " +
+          "ORDER BY num_sold DESC, date DESC " +
           "LIMIT 1) dates"
     )
     ActiveRecord::Base.connection.execute(sql).first

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -6,6 +6,7 @@ class Item < ApplicationRecord
   belongs_to :merchant
   has_many :invoice_items
   has_many :invoices, through: :invoice_items
+  has_many :transactions, through: :invoices
 
   def self.most_revenue(qty)
     qty = qty.to_i
@@ -19,5 +20,22 @@ class Item < ApplicationRecord
         "GROUP BY i.id " +
         "ORDER BY total_revenue DESC " +
         "LIMIT #{qty}")
+  end
+
+  def best_day
+    id = self.id.to_i
+    sql = (
+      "SELECT date as best_day FROM " +
+        "(SELECT DATE(inv.created_at) as date, SUM(ii.quantity) num_sold " +
+          "FROM items i " +
+          "INNER JOIN invoice_items ii ON i.id = ii.item_id " +
+          "INNER JOIN invoices inv ON ii.invoice_id = inv.id " +
+          "INNER JOIN transactions t ON inv.id = t.invoice_id " +
+          "WHERE t.result = 'success' AND i.id = #{id} " +
+          "GROUP BY date " +
+          "ORDER BY num_sold DESC " +
+          "LIMIT 1) dates"
+    )
+    ActiveRecord::Base.connection.execute(sql).first
   end
 end

--- a/app/serializers/best_day_serializer.rb
+++ b/app/serializers/best_day_serializer.rb
@@ -1,0 +1,14 @@
+class BestDaySerializer
+  def initialize(data)
+    @data = data
+  end
+
+  def json
+    {
+      data: {
+        attributes: @data
+      }
+    }
+
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,7 @@ Rails.application.routes.draw do
 
       namespace :items do
         get '/most_revenue', to: 'most_revenue#index'
+        get '/:id/best_day', to: 'best_day#show'
       end
       resources :items, only: [:index, :show]
 

--- a/spec/factories/invoice_item.rb
+++ b/spec/factories/invoice_item.rb
@@ -4,5 +4,7 @@ FactoryBot.define do
     item
     quantity { 1 }
     unit_price { item.unit_price }
+    created_at { invoice.created_at }
+    updated_at { created_at }
   end
 end

--- a/spec/factories/transaction.rb
+++ b/spec/factories/transaction.rb
@@ -3,5 +3,7 @@ FactoryBot.define do
     invoice
     credit_card_number { ('444456567890' + rand(1000..9999).to_s).to_i }
     result { 'success' } # alt 'failed'
+    created_at { invoice.created_at }
+    updated_at { created_at }
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -11,6 +11,7 @@ describe Item do
     it { should belong_to :merchant }
     it { should have_many :invoice_items }
     it { should have_many(:invoices).through(:invoice_items) }
+    it { should have_many(:transactions).through(:invoices) }
   end
 
   describe 'class methods' do
@@ -61,6 +62,46 @@ describe Item do
       expect(Item.most_revenue(1)).to eq([item_3])
       expect(Item.most_revenue(2)).to eq([item_3, item_4])
       expect(Item.most_revenue(3)).to eq([item_3, item_4, item_2])
+    end
+  end
+
+  describe 'instance methods' do
+    it '#best_day' do
+      item = create(:item, unit_price: 1000)
+
+      # day_1: num_sold = 1
+      invoice_1 = create(:invoice, created_at: '2019-10-05 12:34:56 UTC')
+      create(:invoice_item, invoice: invoice_1, item: item, quantity: 1)
+      create(:transaction, invoice: invoice_1)
+
+      # day_2: num_sold = 2
+      invoice_2 = create(:invoice, created_at: '2019-10-04 12:34:56 UTC')
+      invoice_3 = create(:invoice, created_at: '2019-10-04 12:34:56 UTC')
+      create(:invoice_item, invoice: invoice_2, item: item, quantity: 1)
+      create(:invoice_item, invoice: invoice_3, item: item, quantity: 1)
+      create(:transaction, invoice: invoice_2)
+      create(:transaction, invoice: invoice_3)
+
+      # day_3: num_sold = 4
+      invoice_4 = create(:invoice, created_at: '2019-10-03 12:34:56 UTC')
+      invoice_5 = create(:invoice, created_at: '2019-10-03 12:34:56 UTC')
+      create(:invoice_item, invoice: invoice_4, item: item, quantity: 2)
+      create(:invoice_item, invoice: invoice_5, item: item, quantity: 2)
+      create(:transaction, invoice: invoice_4)
+      create(:transaction, invoice: invoice_5)
+
+      # day_4: num_sold = 3
+      invoice_6 = create(:invoice, created_at: '2019-10-01 12:34:56 UTC')
+      invoice_7 = create(:invoice, created_at: '2019-10-01 12:34:56 UTC')
+      invoice_8 = create(:invoice, created_at: '2019-10-01 12:34:56 UTC')
+      create(:invoice_item, invoice: invoice_6, item: item, quantity: 1)
+      create(:invoice_item, invoice: invoice_7, item: item, quantity: 2)
+      create(:invoice_item, invoice: invoice_8, item: item, quantity: 2)
+      create(:transaction, invoice: invoice_6)
+      create(:transaction, invoice: invoice_7)
+      create(:transaction, invoice: invoice_8, result: 'failed')
+
+      expect(item.best_day).to eq({"best_day" => "2019-10-03"})
     end
   end
 end

--- a/spec/requests/api/v1/items_request_spec.rb
+++ b/spec/requests/api/v1/items_request_spec.rb
@@ -98,4 +98,48 @@ describe 'Items API' do
     expect(json['data'][1]['id']).to eq(item_4.id.to_s)
     expect(json['data'][2]['id']).to eq(item_2.id.to_s)
   end
+
+  it 'can return the date of an items best sales' do
+    item = create(:item, unit_price: 1000)
+
+    # day_1: num_sold = 1
+    invoice_1 = create(:invoice, created_at: '2019-10-05 12:34:56 UTC')
+    create(:invoice_item, invoice: invoice_1, item: item, quantity: 1)
+    create(:transaction, invoice: invoice_1)
+
+    # day_2: num_sold = 2
+    invoice_2 = create(:invoice, created_at: '2019-10-04 12:34:56 UTC')
+    invoice_3 = create(:invoice, created_at: '2019-10-04 12:34:56 UTC')
+    create(:invoice_item, invoice: invoice_2, item: item, quantity: 1)
+    create(:invoice_item, invoice: invoice_3, item: item, quantity: 1)
+    create(:transaction, invoice: invoice_2)
+    create(:transaction, invoice: invoice_3)
+
+    # day_3: num_sold = 4
+    invoice_4 = create(:invoice, created_at: '2019-10-03 12:34:56 UTC')
+    invoice_5 = create(:invoice, created_at: '2019-10-03 12:34:56 UTC')
+    create(:invoice_item, invoice: invoice_4, item: item, quantity: 2)
+    create(:invoice_item, invoice: invoice_5, item: item, quantity: 2)
+    create(:transaction, invoice: invoice_4)
+    create(:transaction, invoice: invoice_5)
+
+    # day_4: num_sold = 3
+    invoice_6 = create(:invoice, created_at: '2019-10-01 12:34:56 UTC')
+    invoice_7 = create(:invoice, created_at: '2019-10-01 12:34:56 UTC')
+    invoice_8 = create(:invoice, created_at: '2019-10-01 12:34:56 UTC')
+    create(:invoice_item, invoice: invoice_6, item: item, quantity: 1)
+    create(:invoice_item, invoice: invoice_7, item: item, quantity: 2)
+    create(:invoice_item, invoice: invoice_8, item: item, quantity: 2)
+    create(:transaction, invoice: invoice_6)
+    create(:transaction, invoice: invoice_7)
+    create(:transaction, invoice: invoice_8, result: 'failed')
+
+    get "/api/v1/items/#{item.id}/best_day"
+
+    expect(response).to be_successful
+
+    json = JSON.parse(response.body)
+
+    expect(json['data']['attributes']).to eq({"best_day" => "2019-10-03"})
+  end
 end


### PR DESCRIPTION
- `/api/v1/items/:id/best_day` returns the date of the most sales for a particular item.
- Queries are ordered  by  number sold and by date, so if there is a tie, the most recent date is returned.